### PR TITLE
Added pagination for member list

### DIFF
--- a/app/Http/Controllers/RouteController.php
+++ b/app/Http/Controllers/RouteController.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Support\Facades\Auth;
+use Illuminate\{
+    Support\Facades\Auth,
+    Http\Request
+};
+
 use App\{
     Committee,
     Event,
@@ -166,8 +170,22 @@ class RouteController extends Controller
     // End [Roles]
 
     // [Members]
-    public function showMembers() {
-        return view('admin.members.index');
+    public function showMembers(Request $request) {
+        $perPage = 20;
+        $q = null;
+        $page = 1;
+
+        if ($request->filled('perPage')) $perPage = $request->query('perPage');
+        if ($request->filled('q')) $q = $request->query('q');
+        if ($request->filled('page')) $page = $request->query('page');
+
+        $members = Member::search($q)->with('events')->paginate($perPage);
+
+        if ($request->ajax()) {
+            return view('admin.members.load', ['members'=>$members, 'perPage'=>$perPage, 'q'=>$q, 'page'=>$page])->render();
+        }
+
+        return view('admin.members.index', compact('members', 'perPage', 'q', 'page'));
     }
 
     public function showEditMember($id) {

--- a/app/Member.php
+++ b/app/Member.php
@@ -26,4 +26,14 @@ class Member extends Model
         return $this->hasMany(MeetupAttendee::class, 'student_id', 'student_id');
     }
 
+    public function scopeSearch($query, $q) {
+        if ($q == null) return $query;
+        return $query
+            ->where('email', 'LIKE', "%{$q}%")
+            ->orWhere('name', 'LIKE', "%{$q}%")
+            ->orWhere('student_id', 'LIKE', "%{$q}%")
+            ->orWhere('intake', 'LIKE', "%{$q}%")
+            ->orWhere('skills', 'LIKE', "%{$q}%")
+            ->orWhere('found_us', 'LIKE', "%{$q}%");
+    }
 }

--- a/public/css/admin/style.css
+++ b/public/css/admin/style.css
@@ -205,3 +205,10 @@ a.article:hover {
         border: 2px solid gray !important;
     }    
 }
+
+/* ---------------------------------------------------
+    PAGINATION STYLE
+----------------------------------------------------- */
+.pagination a{
+    margin: 0 !important;
+}

--- a/public/js/custom.js
+++ b/public/js/custom.js
@@ -111,4 +111,18 @@ $(document).ready(function() {
         }
         return false;
     })
+
+    $.fn.doneTyping = function(callback){
+        var _this = $(this);
+        var x_timer;    
+        _this.keyup(function (){
+            clearTimeout(x_timer);
+            x_timer = setTimeout(clear_timer, 500); // Change this timeout if you want faster/slower updates
+        }); 
+    
+        function clear_timer(){
+            clearTimeout(x_timer);
+            callback.call(_this);
+        }
+    }
 });

--- a/resources/views/admin/members/index.blade.php
+++ b/resources/views/admin/members/index.blade.php
@@ -15,68 +15,76 @@
     <br>
     <input type="text" id="myInput" class="form-control border border-info" placeholder="Filter here..">
     <br>
-
-    <div>
-        <table class="table table-responsive-sm">
-            <thead class="thead-dark">
-            <tr>
-                <th>Email</th>
-                <th>Name</th>
-                <th>TP</th>
-                <th>Intake</th>
-                <th>Skills</th>
-                <th>Found us</th>
-                <th>Action</th>
-            </tr>
-            </thead>
-            <tbody id="myTable">
-            @foreach (\App\Member::all() as $member)
-                <tr>
-                    <td>{{ $member->email }} <span style="color: red; text-decoration: underline" data-toggle="modal" data-target="#showEventsAttended-{{ $member->id }}">({{ count($member->events) }})</span></td>
-                    <td>{{ $member->name }}</td>
-                    <td>{{ $member->student_id }}</td>
-                    <td>{{ $member->intake }}</td>
-                    <td>{{ ucfirst($member->skills) }}</td>
-                    <td>{{ $member->found_us }}</td>
-                    <td><a class="btn btn-primary" href="{{ route('dashboard.members.edit', ['id' => $member->id]) }}">Edit</a></td>
-                </tr>
-
-                <div class="modal fade" id="showEventsAttended-{{ $member->id }}" tabindex="-1" role="dialog" aria-labelledby="showEventsAttendedLabel" aria-hidden="true">
-                    <div class="modal-dialog" role="document">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="showEventsAttendedLabel">Attended Events</h5>
-                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                    <span aria-hidden="true">&times;</span>
-                                </button>
-                            </div>
-                            <div class="modal-body">
-                                @if (count($member->events) > 0)
-                                    @foreach ($member->events as $event)
-                                        <h5>- {{ $event->meetup_title }}</h5>
-                                    @endforeach
-                                @endif
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            @endforeach
-            </tbody>
-        </table>
+    @if (count($members) > 0)
+    <div id="memberTableArea" style="position: relative;">
+        @include('admin.members.load')
     </div>
+    @else 
+        <h1 class="text-muted text-center">No members</h1>
+    @endif
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script>
         $(document).ready(function(){
-            $("#myInput").on("keyup", function() {
-                var value = $(this).val().toLowerCase();
-                $("#myTable tr").filter(function() {
-                    $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
-                });
+            const pageUrl = '{{ route('dashboard.members') }}';
+            var $_perPage = {{ $perPage }};
+            var $q = '{{ $q }}';
+            var $_page = {{ $page }};
+            
+            // Get members on page change
+            $('body').on('click', '.pagination a', function(e) {
+                e.preventDefault();
+
+                $_page = (new URL($(this).attr('href'))).searchParams.get('page');
+                
+                if ($q){
+                    var url = pageUrl+'?page='+$_page+'&perPage='+$_perPage+'&q='+$q;
+                } else {
+                    var url = pageUrl+'?page='+$_page+'&perPage='+$_perPage;
+                }
+
+                getMembers(url);
             });
+
+            // Live search
+            // doneTyping function in custom.js
+            $('#myInput').doneTyping(function(callback){
+                $q = $(this).val().toLowerCase();
+
+                if ($q){
+                    var url = pageUrl+'?page=1&perPage='+$_perPage+'&q='+$q;
+                } else {
+                    var url = pageUrl+'?page=1&perPage='+$_perPage;
+                }
+
+                getMembers(url);
+            });
+
+            // Get members on number of rows change
+            $('body').on('change', '#perPage', function() {
+                $_perPage = $(this).val();
+                $q = $('#myInput').val();
+
+                if ($q){
+                    var url = pageUrl+'?page=1&perPage='+$_perPage+'&q='+$q;
+                } else {
+                    var url = pageUrl+'?page=1&perPage='+$_perPage;
+                }
+                
+                getMembers(url);
+            });
+
+            // AJAX function to load data from external file
+            function getMembers(url) {
+                window.history.pushState("", "", url);
+                $.ajax({
+                    url : url
+                }).done(function (data) {
+                    $('#memberTableArea').html(data);  
+                }).fail(function () {
+                    $('#memberTableArea').html('<h1 class="text-muted text-center">Failed to get members.</h1>');
+                });
+            }
         });
     </script>
 @stop

--- a/resources/views/admin/members/load.blade.php
+++ b/resources/views/admin/members/load.blade.php
@@ -1,0 +1,83 @@
+<div class="d-flex align-items-baseline">
+    <div class="p-2">
+        {{ $members->total() }} result(s).
+    </div>
+    <div class="p-2">
+        {{ $members->links() }} 
+    </div>
+    <div class="p-2">
+        Number of Rows 
+        <select name="perPage" id="perPage">
+            @foreach (['20', '50', '100', '250'] as $rowsPerPage)
+                <option @if ($rowsPerPage == $perPage) selected @endif value="{{ $rowsPerPage }}">{{ $rowsPerPage }} </option>
+            @endforeach
+        </select>
+    </div>
+</div>
+<table class="table table-responsive-sm">
+    <thead class="thead-dark">
+    <tr>
+        <th>Email</th>
+        <th>Name</th>
+        <th>TP</th>
+        <th>Intake</th>
+        <th>Skills</th>
+        <th>Found us</th>
+        <th>Action</th>
+    </tr>
+    </thead>
+    <tbody id="myTable">
+    @foreach ($members as $member)
+        <tr>
+            <td>{{ $member->email }} <span style="color: red; text-decoration: underline" data-toggle="modal" data-target="#showEventsAttended-{{ $member->id }}">({{ count($member->events) }})</span></td>
+            <td>{{ $member->name }}</td>
+            <td>{{ $member->student_id }}</td>
+            <td>{{ $member->intake }}</td>
+            <td>{{ ucfirst($member->skills) }}</td>
+            <td>{{ $member->found_us }}</td>
+            <td><a class="btn btn-primary" href="{{ route('dashboard.members.edit', ['id' => $member->id]) }}">Edit</a></td>
+        </tr>
+
+        <div class="modal fade" id="showEventsAttended-{{ $member->id }}" tabindex="-1" role="dialog" aria-labelledby="showEventsAttendedLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="showEventsAttendedLabel">Attended Events</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        @if (count($member->events) > 0)
+                            @foreach ($member->events as $event)
+                                <h5>- {{ $event->meetup_title }}</h5>
+                            @endforeach
+                        @else
+                            <h5 class="text-muted text-center">No attended events.</h5>
+                        @endif
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endforeach
+    </tbody>
+</table>
+<div class="d-flex align-items-baseline">
+    <div class="p-2">
+        {{ $members->total() }} result(s).
+    </div>
+    <div class="p-2">
+        {{ $members->links() }} 
+    </div>
+    <div class="p-2">
+        Number of Rows 
+        <select name="perPage" id="perPage">
+            @foreach (['20', '50', '100', '250'] as $rowsPerPage)
+                <option @if ($rowsPerPage == $perPage) selected @endif value="{{ $rowsPerPage }}">{{ $rowsPerPage }} </option>
+            @endforeach
+        </select>
+    </div>
+</div>


### PR DESCRIPTION
# Introduction
<!-- Explain existing problems or why this pull request is necessary -->
Added pagination for member list and also row count.

### Relevant issues
<!-- List relevant issues here -->
* Fixes #49 
* Fixes #17 

## Changes
### Behavioural changes
<!-- Any change in how the CMS behaves, or its performance? -->

- Member list is paginated on default of 20 per page and can be increased from the dropdown to 50, 100 and 250.
- Search function has been added to member model
- `doneTyping` function has been added to custom.js to check if user is done typing in textareas.

## Follow-up
<!-- Suggest any actions to be done before/after merging this pull request -->
none

## Tests
<!--
Details should be provided of tests done. Simply saying "tested" or equivalent is not acceptable.

Attach scripts or actions to test this pull request, as well as the result (screenshot)
-->

- Clicked on paginated links and am brought to correct pages
- Changed number of rows per page, list updates as expected
- Clicked on paginated links after changed number of rows. Works as expected.
- Input query to filter, initially without changing anything, then changed number of rows, works as expected.
- Copied link after changing number of rows, page number and query individually, then copied when done altogether, works as expected.